### PR TITLE
[BE]feat: 모임 가입 신청 api 작성

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -22,6 +23,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 @Configuration
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtProvider jwtProvider;

--- a/backend/src/main/java/com/example/backend/controller/QuestionController.java
+++ b/backend/src/main/java/com/example/backend/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package com.example.backend.controller;
 
 
+import com.example.backend.domain.User;
 import com.example.backend.dto.QuestionCreateRequest;
 import com.example.backend.dto.QuestionResponseRequest;
 
@@ -11,6 +12,7 @@ import com.example.backend.service.QuestionService;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -61,12 +63,11 @@ public class QuestionController {
     @PatchMapping("/{questionId}")
     public ResponseEntity<ApiResponse<Void>> updateQuestion(
             @PathVariable Long questionId,
-            @Valid @RequestBody QuestionUpdateRequest request
-            //@AuthenticationPrincipal CustomUserDetails user
+            @Valid @RequestBody QuestionUpdateRequest request,
+            @AuthenticationPrincipal User user
     ) {
-        Long tmpUserId = 1L;
 
-        questionService.updateQuestion(questionId, tmpUserId, request);
+        questionService.updateQuestion(questionId, user.getId(), request);
 
         return ResponseEntity.ok(ApiResponse.success("질문이 수정되었습니다."));
     }
@@ -74,12 +75,11 @@ public class QuestionController {
 
     @DeleteMapping("/{questionId}")
     public ResponseEntity<ApiResponse<Void>> deleteQuestion(
-            @PathVariable Long questionId
-            //@AuthenticationPrincipal CustomUserDetails user
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal User user
     ) {
-        Long tmpUserId = 1L;
 
-        questionService.deleteQuestion(questionId, tmpUserId);
+        questionService.deleteQuestion(questionId, user.getId());
         return ResponseEntity.ok(ApiResponse.success("질문이 삭제되었습니다."));
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/Meeting.java
+++ b/backend/src/main/java/com/example/backend/domain/Meeting.java
@@ -106,6 +106,7 @@ public class Meeting extends BaseEntity{
         }
     }
 
+
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
     }

--- a/backend/src/main/java/com/example/backend/dto/MeetingJoinRequestDto.java
+++ b/backend/src/main/java/com/example/backend/dto/MeetingJoinRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.backend.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class MeetingJoinRequestDto {
+    @Size(max = 30, message = "가입 문구는 30자 이내로 작성 바랍니다.")
+    private String message;
+}

--- a/backend/src/main/java/com/example/backend/global/exception/custom/ErrorCode.java
+++ b/backend/src/main/java/com/example/backend/global/exception/custom/ErrorCode.java
@@ -51,6 +51,10 @@ public enum ErrorCode {
 	MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING-002", "해당 모임이 존재하지 않습니다."),
 	MEETING_MEMBER_FORBIDDEN(HttpStatus.FORBIDDEN, "MEETING-003", "모임 멤버만 접근할 수 있습니다."),
 	MEETING_HOST_ONLY(HttpStatus.FORBIDDEN, "MEETING-004", "방장만 접근할 수 있습니다."),
+	ALREADY_MEETING_REQUESTED(HttpStatus.BAD_REQUEST, "MEETING-005", "이미 모임에 신청하셨습니다."),
+	MEETING_IS_FULL(HttpStatus.BAD_REQUEST, "MEETING-006", "이미 모임의 정원이 초과되었습니다."),
+	ALREADY_MEETING_MEMBER(HttpStatus.BAD_REQUEST, "MEETING-007", "이미 모임의 멤버입니다.")
+
 
 	;
 

--- a/backend/src/main/java/com/example/backend/repository/MeetingJoinRequestRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/MeetingJoinRequestRepository.java
@@ -1,7 +1,12 @@
 package com.example.backend.repository;
 
+import com.example.backend.domain.Meeting;
 import com.example.backend.domain.MeetingJoinRequest;
+import com.example.backend.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingJoinRequestRepository extends JpaRepository<MeetingJoinRequest, Long> {
+
+    boolean existsByMeetingAndUser(Meeting meeting, User user);
+
 }

--- a/backend/src/main/java/com/example/backend/repository/MeetingMemberRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/MeetingMemberRepository.java
@@ -1,6 +1,8 @@
 package com.example.backend.repository;
 
+import com.example.backend.domain.Meeting;
 import com.example.backend.domain.MeetingMember;
+import com.example.backend.domain.User;
 import com.example.backend.enums.MeetingMemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +12,6 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
             Long userId,
             MeetingMemberRole role
     );
+
+    boolean existsByMeetingAndUser(Meeting meeting, User user);
 }


### PR DESCRIPTION
✨ 작업 내용

* 모임에 가입 신청을 할 수 있는 API를 구현했습니다.
* 로그인된 사용자만 가입 신청이 가능하도록 인증 처리를 적용했습니다.
* 이미 가입된 사용자, 정원이 초과된 모임, 모집이 종료된 모임에 대해 예외 처리를 추가했습니다.

🔍 상세 구현
* 가입 가능 여부 검증 로직 추가
* 이미 가입된 멤버인지 확인
* 모임 정원 초과 여부 확인
* 모집 상태(RECRUITING) 여부 확인
* 가입 신청 성공 시 참여 요청 상태로 저장